### PR TITLE
docs: add MacPorts install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ and [jiq](https://github.com/fiatjaf/jiq).
 brew install ynqa/tap/jnv
 ```
 
+### MacPorts
+
+```bash
+sudo port install jnv
+```
+
+More info [here](https://ports.macports.org/port/jnv/)
+
 ### Cargo
 
 #### Requirements


### PR DESCRIPTION
`jnv` is now available via MacPorts: https://ports.macports.org/port/jnv/