### PR TITLE
fix: consider whether first char or not at Array

### DIFF
--- a/src/jnv.rs
+++ b/src/jnv.rs
@@ -56,7 +56,8 @@ impl Jnv {
                 } else {
                     segments
                         .iter()
-                        .map(|segment| match segment {
+                        .enumerate()
+                        .map(|(i, segment)| match segment {
                             JsonPathSegment::Key(key) => {
                                 if key.contains('.') || key.contains('-') || key.contains('@') {
                                     format!(".\"{}\"", key)
@@ -64,7 +65,13 @@ impl Jnv {
                                     format!(".{}", key)
                                 }
                             }
-                            JsonPathSegment::Index(index) => format!("[{}]", index),
+                            JsonPathSegment::Index(index) => {
+                                if i == 0 {
+                                    format!(".[{}]", index)
+                                } else {
+                                    format!("[{}]", index)
+                                }
+                            }
                         })
                         .collect::<String>()
                 }


### PR DESCRIPTION
I noticed that the suggestions are invalid when the first element is an Array.

```
% docker inspect alpine | jnv
❯❯ .
❯ .
  [0]
  [0].Id
[
  {
    "Id": "sha256:ace17d5d883e9ea5a21138d0608d60aa2376c68f616c55b0b7e73fba6
    "RepoTags": [
      "alpine:latest"
    ],
```