### PR TITLE
Improving perfomance for JSON Lines format

### DIFF
--- a/src/jnv.rs
+++ b/src/jnv.rs
@@ -35,11 +35,18 @@ mod keymap;
 /// # Returns
 /// An `anyhow::Result` wrapping a vector of `serde_json::Value`. On success, it contains the parsed
 /// JSON data. On failure, it contains an error detailing what went wrong during parsing.
-fn deserialize_json(json_str: &str) -> anyhow::Result<Vec<serde_json::Value>> {
-    Deserializer::from_str(json_str)
-        .into_iter::<serde_json::Value>()
-        .map(|res| res.map_err(anyhow::Error::from))
-        .collect::<anyhow::Result<Vec<serde_json::Value>>>()
+fn deserialize_json(json_str: &str, limit_length: Option<usize>) -> anyhow::Result<Vec<serde_json::Value>> {
+    match limit_length {
+        Some(l) => Deserializer::from_str(json_str)
+            .into_iter::<serde_json::Value>()
+            .take(l)
+            .map(|res| res.map_err(anyhow::Error::from))
+            .collect::<anyhow::Result<Vec<serde_json::Value>>>(),
+        None => Deserializer::from_str(json_str)
+            .into_iter::<serde_json::Value>()
+            .map(|res| res.map_err(anyhow::Error::from))
+            .collect::<anyhow::Result<Vec<serde_json::Value>>>(),
+    }
 }
 
 fn run_jq(query: &str, json_stream: &[serde_json::Value]) -> anyhow::Result<Vec<String>> {
@@ -96,6 +103,7 @@ pub struct Jnv {
     suggest: Suggest,
 
     json_expand_depth: Option<usize>,
+    json_limit_length: Option<usize>,
     no_hint: bool,
 }
 
@@ -107,9 +115,10 @@ impl Jnv {
         suggestions: listbox::State,
         json_theme: json::Theme,
         json_expand_depth: Option<usize>,
+        json_limit_length: Option<usize>,
         no_hint: bool,
     ) -> Result<Prompt<Self>> {
-        let input_stream = deserialize_json(&input)?;
+        let input_stream = deserialize_json(&input, json_limit_length)?;
 
         let mut trie = FilterTrie::default();
         trie.insert(".", input_stream.clone());
@@ -160,6 +169,7 @@ impl Jnv {
                 trie,
                 suggest,
                 json_expand_depth,
+                json_limit_length,
                 no_hint,
                 input_stream,
             },
@@ -252,7 +262,7 @@ impl promkit::Renderer for Jnv {
                                         JsonStream::new(searched.clone(), self.json_expand_depth);
                                 }
                             } else {
-                                match deserialize_json(&ret.join("\n")) {
+                                match deserialize_json(&ret.join("\n"), self.json_limit_length) {
                                     Ok(jsonl) => {
                                         let stream =
                                             JsonStream::new(jsonl.clone(), self.json_expand_depth);

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,18 @@ pub struct Args {
     pub json_expand_depth: Option<usize>,
 
     #[arg(
+        short = 's',
+        long = "limit-length",
+        default_value = "50",
+        help = "Limit length of JSON array in the visualization.",
+        long_help = "
+        Specifies the limit length to load JSON array in the visualization.
+        Note: Increasing this length can significantly slow down the display for large datasets.
+        "
+    )]
+    pub json_limit_length: Option<usize>,
+
+    #[arg(
         short = 'l',
         long = "suggestion-list-length",
         default_value = "3",
@@ -208,6 +220,7 @@ fn main() -> Result<()> {
         suggestions,
         json_theme,
         args.json_expand_depth,
+        args.json_limit_length,
         args.no_hint,
     )?;
     let _ = prompt.run()?;


### PR DESCRIPTION
This patch improves performance when loading JSON Lines format.

Loading JSON Lines cause significant slowdown and stop accepting keys, even if the length is moderate.
This situation can be reproduced like follows.

```sh
seq 10000 |  jq -cs '{"id":.[]}' | jnv
```

For visualization and suggestions, the entire long list is not necessary, but a partial list of some length is enough.
Therefore I have created simple patch.

- Give a limit length for arrays as loading JSON Lines format
- Add `--limit-length` option to be able to specify the length

I often deal with JSON-Lines files that have tens of thousands of lines, so I hope jnv can handle them comfortably.