### PR TITLE
Add requirements for Cargo installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ nix-shell -p jnv
 
 - [autoconf](https://www.gnu.org/software/autoconf/)
 - [automake](https://www.gnu.org/software/automake/)
+- [libtool](https://www.gnu.org/software/libtool/)
+- [clang](https://clang.llvm.org/)
 
 ```bash
 cargo install jnv


### PR DESCRIPTION
While installing jnv by executing `cargo install jnv` on a bare Ubuntu (23.10), I had to install more dependencies to succeed.

1. `apt install libtool` helped me to overcome this error:
```
error: Libtool library used but 'LIBTOOL' is undefined
```
2. Then I did `apt install libclang1` for:
```
Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
```
3. Finally, `apt install clang` for:
```
    /usr/include/stdio.h:33:10: fatal error: 'stddef.h' file not found
  Error: clang diagnosed error: /usr/include/stdio.h:33:10: fatal error: 'stddef.h' file not found
```