### PR TITLE
Construct clipboard on copy phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,13 @@
-## Build stage
-FROM rust:1.79-alpine3.20 as builder
-
-RUN rustup target add x86_64-unknown-linux-musl
-
-RUN apk add musl-dev
+# Build stage
+FROM rust:1.80.0-slim-bookworm as builder
 
 WORKDIR /jnv
-
 COPY . /jnv
+RUN cargo build --release
 
-RUN cargo build --target=x86_64-unknown-linux-musl --release
+# Final stage
+FROM debian:bookworm-slim
 
-## Final image
-
-FROM scratch
-
-COPY --from=builder /jnv/target/x86_64-unknown-linux-musl/release/jnv /bin/jnv
+COPY --from=builder /jnv/target/release/jnv /bin/jnv
 
 ENTRYPOINT ["/bin/jnv"]

--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ See [package entry on search.nixos.org](https://search.nixos.org/packages?channe
 nix-shell -p jnv
 ```
 
+### Docker
+
+Build
+(In the near future, the image will be available on something of registries)
+
+```bash
+docker build -t jnv .
+```
+
+And Run
+(The following commad is just an example. Please modify the path to the file you want to mount)
+
+```bash
+docker run -it --rm -v $(pwd)/debug.json:/jnv/debug.json jnv /jnv/debug.json
+```
+
 ### Cargo
 
 ```bash
@@ -85,11 +101,7 @@ cargo install jnv
 
 ```bash
 cat data.json | jnv
-```
-
-Or
-
-```bash
+# or
 jnv data.json
 ```
 

--- a/src/jnv.rs
+++ b/src/jnv.rs
@@ -228,14 +228,14 @@ impl Jnv {
         }
     }
 
-    fn content_to_clipboard(&mut self) {
+    fn store_content_to_clipboard(&mut self) {
         self.store_to_clipboard(
             &self.json.json_str(),
             "Copied selected content to clipboard!",
         );
     }
 
-    fn query_to_clipboard(&mut self) {
+    fn store_query_to_clipboard(&mut self) {
         self.store_to_clipboard(
             &self
                 .filter_editor

--- a/src/jnv.rs
+++ b/src/jnv.rs
@@ -108,7 +108,6 @@ pub struct Jnv {
 
     json_expand_depth: Option<usize>,
     no_hint: bool,
-    clipboard: Clipboard,
 }
 
 impl Jnv {
@@ -183,7 +182,6 @@ impl Jnv {
                 json_expand_depth,
                 no_hint,
                 input_stream,
-                clipboard: Clipboard::new()?,
             },
         })
     }
@@ -196,35 +194,57 @@ impl Jnv {
         }
     }
 
+    fn store_to_clipboard(&mut self, content: &str, hint: &str) {
+        match Clipboard::new() {
+            Ok(mut clipboard) => match clipboard.set_text(content) {
+                Ok(_) => {
+                    self.update_hint_message(
+                        hint.to_string(),
+                        StyleBuilder::new().fgc(Color::Grey).build(),
+                    );
+                }
+                Err(e) => {
+                    self.update_hint_message(
+                        format!("Failed to copy to clipboard: {}", e),
+                        StyleBuilder::new()
+                            .fgc(Color::Red)
+                            .attrs(Attributes::from(Attribute::Bold))
+                            .build(),
+                    );
+                }
+            },
+            // arboard fails (in the specific environment like linux?) on Clipboard::new()
+            // suppress the errors (but still show them) not to break the prompt
+            // https://github.com/1Password/arboard/issues/153
+            Err(e) => {
+                self.update_hint_message(
+                    format!("Failed to setup clipboard: {}", e),
+                    StyleBuilder::new()
+                        .fgc(Color::Red)
+                        .attrs(Attributes::from(Attribute::Bold))
+                        .build(),
+                );
+            }
+        }
+    }
+
     fn content_to_clipboard(&mut self) {
-        let content = self.json.json_str();
-        let _ = self.clipboard.set_text(content);
-
-        let clipboard_hint = String::from("Copied selected content to clipboard!");
-        let style = StyleBuilder::new()
-            .fgc(Color::Grey)
-            .attrs(Attributes::from(Attribute::Italic))
-            .build();
-
-        self.update_hint_message(clipboard_hint, style);
+        self.store_to_clipboard(
+            &self.json.json_str(),
+            "Copied selected content to clipboard!",
+        );
     }
 
     fn query_to_clipboard(&mut self) {
-        let query = self
-            .filter_editor
-            .after()
-            .texteditor
-            .text_without_cursor()
-            .to_string();
-        let _ = self.clipboard.set_text(query);
-
-        let clipboard_hint = String::from("Copied jq query to clipboard!");
-        let style = StyleBuilder::new()
-            .fgc(Color::Grey)
-            .attrs(Attributes::from(Attribute::Italic))
-            .build();
-
-        self.update_hint_message(clipboard_hint, style);
+        self.store_to_clipboard(
+            &self
+                .filter_editor
+                .after()
+                .texteditor
+                .text_without_cursor()
+                .to_string(),
+            "Copied jq query to clipboard!",
+        );
     }
 }
 

--- a/src/jnv/keymap.rs
+++ b/src/jnv/keymap.rs
@@ -194,7 +194,7 @@ pub fn default(event: &Event, jnv: &mut crate::jnv::Jnv) -> anyhow::Result<Promp
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         }) => {
-            jnv.content_to_clipboard();
+            jnv.store_content_to_clipboard();
         }
 
         Event::Key(KeyEvent {
@@ -203,7 +203,7 @@ pub fn default(event: &Event, jnv: &mut crate::jnv::Jnv) -> anyhow::Result<Promp
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         }) => {
-            jnv.query_to_clipboard();
+            jnv.store_query_to_clipboard();
         }
 
         Event::Key(KeyEvent {


### PR DESCRIPTION
There is a possibility of an error occurring during the instantiation of Clipboard (https://github.com/1Password/arboard/issues/153). Therefore, I modified it to instantiate at the time of copying to display and suppress the error if it occurs.