### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,13 @@
-## Build stage
-FROM rust:1.79-alpine3.20 as builder
-
-RUN rustup target add x86_64-unknown-linux-musl
-
-RUN apk add musl-dev
+# Build stage
+FROM rust:1.80.0-slim-bookworm as builder
 
 WORKDIR /jnv
-
 COPY . /jnv
+RUN cargo build --release
 
-RUN cargo build --target=x86_64-unknown-linux-musl --release
+# Final stage
+FROM debian:bookworm-slim
 
-## Final image
-
-FROM scratch
-
-COPY --from=builder /jnv/target/x86_64-unknown-linux-musl/release/jnv /bin/jnv
+COPY --from=builder /jnv/target/release/jnv /bin/jnv
 
 ENTRYPOINT ["/bin/jnv"]

--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ See [package entry on search.nixos.org](https://search.nixos.org/packages?channe
 nix-shell -p jnv
 ```
 
+### Docker
+
+Build
+(In the near future, the image will be available on something of registries)
+
+```bash
+docker build -t jnv .
+```
+
+And Run
+(The following commad is just an example. Please modify the path to the file you want to mount)
+
+```bash
+docker run -it --rm -v $(pwd)/debug.json:/jnv/debug.json jnv /jnv/debug.json
+```
+
 ### Cargo
 
 ```bash
@@ -85,11 +101,7 @@ cargo install jnv
 
 ```bash
 cat data.json | jnv
-```
-
-Or
-
-```bash
+# or
 jnv data.json
 ```
 


### PR DESCRIPTION
Use debian slim image instead of alpine.

Current `-slim` image is already sufficiently small. Although I don't think there are any dependencies at the moment, I will prepare an environment using glibc instead of musl as much as possible.