### PR TITLE
feat(config): add JQ_COLORS environment variable support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
   test:

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     if args.write_default_config {
-        return args.write_default_config().map_err(Into::into);
+        return args.write_default_config();
     }
 
     let input = parse_input(&args)?;


### PR DESCRIPTION
> [!WARNING] 
> This would be respected when the default configuration file is created as part of #70 but after, the configuration file would take precedence.

> [!NOTE]
> Boolean is considered a single value currently, but JQ treats `false` and `true` as different.  I'm choosing to use `true` only at the moment.

- Introduced JqColors struct to handle JQ_COLORS parsing
- Updated ConfigContentStyle to support conversion from &str
- Modified Config default implementation to use JQ_COLORS
- Added tests for JqColors parsing and ConfigContentStyle conversion
- Updated ConfigFile to use ConfigContentStyle instead of ContentStyle
- Updated Config to use CrosstermContentStyle instead of ContentStyle
- Added JqColors parsing from environment variable in Config default


[![Alternate Text]](https://github.com/user-attachments/assets/633437b2-ce85-4303-8ad7-17de0dcd84b7 "See")

