### PR TITLE
chore: remove `aarch64-pc-windows-msvc`

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,12 +8,16 @@ cargo-dist-version = "0.28.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["homebrew"]
+installers = ["shell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
 tap = "ynqa/homebrew-tap"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "armv7-unknown-linux-gnueabihf", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "armv7-unknown-linux-gnueabihf", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
+# Path that installers should place binaries in
+install-path = "CARGO_HOME"
+# Whether to install an updater program
+install-updater = false


### PR DESCRIPTION
Since I encountered the following errors on building for the target `aarch64-pc-windows-msvc`. (Do you know about the error @jnichols0?)
- https://github.com/ynqa/jnv/actions/runs/14196515670/job/39772834481

Therefore, on release of v0.6.0, `aarch64-pc-windows-msvc` target is canceled