### PR TITLE
feat(keybinds): bind Home/End and Alt+Backspace in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ cat data.json | jnv -- --write-to-stdout > result.json
 | <kbd>Tab</kbd> | Enter suggestion |
 | <kbd>←</kbd> | Move cursor left |
 | <kbd>→</kbd> | Move cursor right |
-| <kbd>Ctrl + A</kbd> | Move cursor to line start |
-| <kbd>Ctrl + E</kbd> | Move cursor to line end |
+| <kbd>Ctrl + A</kbd>, <kbd>Home</kbd> | Move cursor to line start |
+| <kbd>Ctrl + E</kbd>, <kbd>End</kbd> | Move cursor to line end |
 | <kbd>Backspace</kbd> | Delete character before cursor |
 | <kbd>Ctrl + U</kbd> | Clear entire line |
 | <kbd>Alt + B</kbd>   | Move the cursor to the previous nearest character within set(`.`,`\|`,`(`,`)`,`[`,`]`) |
 | <kbd>Alt + F</kbd>   | Move the cursor to the next nearest character within set(`.`,`\|`,`(`,`)`,`[`,`]`) |
-| <kbd>Ctrl + W</kbd>  | Erase to the previous nearest character within set(`.`,`\|`,`(`,`)`,`[`,`]`) |
+| <kbd>Ctrl + W</kbd>, <kbd>Alt + Backspace</kbd>  | Erase to the previous nearest character within set(`.`,`\|`,`(`,`)`,`[`,`]`) |
 | <kbd>Alt + D</kbd>   | Erase to the next nearest character within set(`.`,`\|`,`(`,`)`,`[`,`]`) |
 
 #### Suggestion in Editor (after <kbd>Tab</kbd>)
@@ -369,9 +369,9 @@ backward = ["Left"]
 forward = ["Right"]
 
 # Move cursor to beginning of line
-move_to_head = ["Ctrl+A"]
+move_to_head = ["Ctrl+A", "Home"]
 # Move cursor to end of line
-move_to_tail = ["Ctrl+E"]
+move_to_tail = ["Ctrl+E", "End"]
 # Move cursor to previous word boundary
 move_to_previous_nearest = ["Alt+B"]
 # Move cursor to next word boundary
@@ -383,7 +383,7 @@ erase = ["Backspace"]
 erase_all = ["Ctrl+U"]
 
 # Delete from cursor to previous word boundary
-erase_to_previous_nearest = ["Ctrl+W"]
+erase_to_previous_nearest = ["Ctrl+W", "Alt+Backspace"]
 # Delete from cursor to next word boundary
 erase_to_next_nearest = ["Alt+D"]
 # Trigger completion

--- a/default.toml
+++ b/default.toml
@@ -136,9 +136,9 @@ backward = ["Left"]
 forward = ["Right"]
 
 # Move cursor to beginning of line
-move_to_head = ["Ctrl+A"]
+move_to_head = ["Ctrl+A", "Home"]
 # Move cursor to end of line
-move_to_tail = ["Ctrl+E"]
+move_to_tail = ["Ctrl+E", "End"]
 # Move cursor to previous word boundary
 move_to_previous_nearest = ["Alt+B"]
 # Move cursor to next word boundary
@@ -150,7 +150,7 @@ erase = ["Backspace"]
 erase_all = ["Ctrl+U"]
 
 # Delete from cursor to previous word boundary
-erase_to_previous_nearest = ["Ctrl+W"]
+erase_to_previous_nearest = ["Ctrl+W", "Alt+Backspace"]
 # Delete from cursor to next word boundary
 erase_to_next_nearest = ["Alt+D"]
 # Trigger completion


### PR DESCRIPTION
## Summary

Adds two commonly-requested default editor keybindings:

- **Home / End** → move cursor to line start / end, alongside the existing `Ctrl+A` / `Ctrl+E` (#61)
- **Alt+Backspace** → erase to the previous word boundary, alongside the existing `Ctrl+W` (#71)

## Implementation

Both map to **existing** editor actions (`move_to_head`, `move_to_tail`, `erase_to_previous_nearest`) — only the default keybind sets in `default.toml` and the README keymap change. `termcfg` parses the `Home` / `End` / `Alt+Backspace` notation natively, so no code changes are needed.

## Notes

- Existing users keep their on-disk config; the new binds apply to freshly generated configs and the built-in defaults. Users who want them can add `"Home"`/`"End"`/`"Alt+Backspace"` to the relevant `[keybinds.on_editor]` entries.
- The README's embedded config block was updated in lockstep with `default.toml` to avoid drift.

Closes #61
Closes #71