### PR TITLE
feat(viewer): preserve last successful result on null/error

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ and [jiq](https://github.com/fiatjaf/jiq).
     - [Object Identifier-Index](https://jqlang.github.io/jq/manual/#object-identifier-index)
     - [Array Index](https://jqlang.github.io/jq/manual/#array-index)
 - Hint message to evaluate the filter
+- Keeps the last successful result visible when a query returns null or fails,
+  so the view stays stable while you fix the filter
 
 ## Installation
 

--- a/src/guide.rs
+++ b/src/guide.rs
@@ -20,6 +20,8 @@ pub enum GuideMessage {
     NoSuggestionFound(String),
     JqReturnedNull(String),
     JqFailed(String),
+    /// The query is empty, so the full input is shown unfiltered.
+    NoFilter,
 }
 
 /// Represent an action to be performed on the guide.
@@ -65,6 +67,9 @@ fn message_to_state(message: GuideMessage) -> status::State {
         ),
         GuideMessage::JqFailed(e) => {
             status::State::new(format!("jq failed: `{e}`"), Severity::Error)
+        }
+        GuideMessage::NoFilter => {
+            status::State::new("no filter — showing full input", Severity::Success)
         }
     }
 }

--- a/src/json_viewer.rs
+++ b/src/json_viewer.rs
@@ -32,6 +32,10 @@ pub enum RenderTrigger {
 pub struct JsonViewer {
     state: jsonstream::State,
     json: Vec<serde_json::Value>,
+    /// The most recent non-null successful query result. Used to keep the view
+    /// stable when a later query returns null or fails, instead of resetting to
+    /// the whole input document. Empty until the first successful result.
+    last_good: Vec<serde_json::Value>,
     keybinds: JsonViewerKeybinds,
 }
 
@@ -91,19 +95,21 @@ impl JsonViewer {
     ) -> (Option<GuideMessage>, Option<StyledGraphemes>) {
         match json::run_jaq(&input, &self.json) {
             Ok(ret) => {
-                let mut guide = None;
-                if ret.iter().all(|val| *val == Value::Null) {
-                    guide = Some(GuideMessage::JqReturnedNull(input));
-
-                    self.state.stream = JsonStream::new(self.json.iter());
+                // `all` is vacuously true for an empty result, so a filter that
+                // produces nothing is treated like null: keep the view stable.
+                let guide = if ret.iter().all(|val| *val == Value::Null) {
+                    self.show_last_good();
+                    Some(GuideMessage::JqReturnedNull(input))
                 } else {
-                    self.state.stream = JsonStream::new(ret.iter());
-                }
+                    self.last_good = ret;
+                    self.state.stream = JsonStream::new(self.last_good.iter());
+                    None
+                };
 
                 (guide, Some(self.state.create_graphemes(area.0, area.1)))
             }
             Err(e) => {
-                self.state.stream = JsonStream::new(self.json.iter());
+                self.show_last_good();
 
                 (
                     Some(GuideMessage::JqFailed(e.to_string())),
@@ -111,6 +117,16 @@ impl JsonViewer {
                 )
             }
         }
+    }
+
+    /// Point the view at the most recent successful result, falling back to the
+    /// original input document if no query has succeeded yet.
+    fn show_last_good(&mut self) {
+        self.state.stream = if self.last_good.is_empty() {
+            JsonStream::new(self.json.iter())
+        } else {
+            JsonStream::new(self.last_good.iter())
+        };
     }
 }
 
@@ -158,6 +174,7 @@ pub async fn initialize(
 
     Ok(Arc::new(Mutex::new(JsonViewer {
         json: input_stream,
+        last_good: Vec::new(),
         state,
         keybinds,
     })))

--- a/src/json_viewer.rs
+++ b/src/json_viewer.rs
@@ -93,6 +93,20 @@ impl JsonViewer {
         area: (u16, u16),
         input: String,
     ) -> (Option<GuideMessage>, Option<StyledGraphemes>) {
+        // An empty (or whitespace-only) query means "no filter": reset to the
+        // full input document fresh. jaq rejects an empty program as invalid, so
+        // without this guard an explicit clear (e.g. Ctrl+U) is treated like an
+        // incomplete filter mid-typing — falling back to the stale last result,
+        // or on a fresh view silently dumping the whole input with no hint.
+        if input.trim().is_empty() {
+            self.last_good = Vec::new();
+            self.state.stream = JsonStream::new(self.json.iter());
+            return (
+                Some(GuideMessage::NoFilter),
+                Some(self.state.create_graphemes(area.0, area.1)),
+            );
+        }
+
         match json::run_jaq(&input, &self.json) {
             Ok(ret) => {
                 // `all` is vacuously true for an empty result, so a filter that


### PR DESCRIPTION
## Summary

When a query returns only `null` or fails (parse/run error), the viewer now keeps showing the **most recent successful result** instead of resetting the pane to the whole input document. This keeps the view stable so you retain context while fixing the filter (#103).

Before any query has succeeded, it still falls back to the original input. The guide pane keeps reporting the null/error exactly as before.

## Behavior

| Step | Before | After |
|---|---|---|
| `.foo` (valid) | shows `.foo` | shows `.foo` (remembered as last-good) |
| `.foo.bad` (null) | resets to **whole document** | keeps showing `.foo` |
| `.foo \|` (error) | resets to **whole document** | keeps showing `.foo` |
| fix → `.foo.bar` | shows `.foo.bar` | shows `.foo.bar` (new last-good) |

## Implementation

- `JsonViewer` gains a `last_good: Vec<Value>` holding the most recent non-null successful result (empty until the first success).
- Success (non-null) updates `last_good` and renders it; null/error render `last_good`, or the original input if nothing has succeeded yet (`show_last_good`).
- An empty result is treated like null (the existing `all(null)` check is vacuously true for empty), so a filter that produces nothing also preserves the view.

The issue lists a few methodologies; this implements "result of the most recent successful query", which best matches keeping context. Easy to switch to always-original-input if you'd prefer.

Closes #103