### PR TITLE
feat(viewer): stay quiet on incomplete/invalid filters while typing

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -9,6 +9,30 @@ use promkit_widgets::{
     serde_json::{self, Deserializer, Value},
 };
 
+/// An error from running a jq filter, split by phase so callers can treat an
+/// incomplete or syntactically invalid expression — common while the user is
+/// still typing — differently from a genuine runtime failure.
+#[derive(Debug)]
+pub enum JaqError {
+    /// The filter could not be parsed or compiled. This is the expected state
+    /// for a half-typed expression (e.g. a trailing `|`), so callers typically
+    /// stay quiet rather than surfacing it as an error.
+    Invalid(String),
+    /// The filter parsed and compiled but failed during execution. This is a
+    /// real error worth reporting, since the filter itself is well-formed.
+    Execution(String),
+}
+
+impl std::fmt::Display for JaqError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JaqError::Invalid(msg) | JaqError::Execution(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for JaqError {}
+
 /// Get all JSON paths from the input JSON string,
 /// respecting the max_streams limit if provided.
 pub async fn get_all_paths(
@@ -38,7 +62,7 @@ pub fn deserialize(
 pub fn run_jaq(
     query: &str,
     json_stream: &[serde_json::Value],
-) -> anyhow::Result<Vec<serde_json::Value>> {
+) -> Result<Vec<serde_json::Value>, JaqError> {
     let arena = Arena::default();
     let loader = Loader::new(jaq_std::defs().chain(jaq_json::defs()));
     let modules = loader
@@ -49,11 +73,12 @@ pub fn run_jaq(
                 path: (),
             },
         )
-        .map_err(|errs| anyhow::anyhow!("jq filter parsing failed: {errs:?}"))?;
+        // Parse failures are usually just an incomplete expression mid-typing.
+        .map_err(|_| JaqError::Invalid("incomplete or invalid jq filter".to_string()))?;
     let filter = Compiler::default()
         .with_funs(jaq_std::funs().chain(jaq_json::funs()))
         .compile(modules)
-        .map_err(|errs| anyhow::anyhow!("jq filter compilation failed: {errs:?}"))?;
+        .map_err(|_| JaqError::Invalid("invalid jq filter".to_string()))?;
 
     let mut ret = Vec::<serde_json::Value>::new();
 
@@ -63,7 +88,7 @@ pub fn run_jaq(
         for item in out {
             match item {
                 Ok(val) => ret.push(val.into()),
-                Err(err) => return Err(anyhow::anyhow!("jq filter execution failed: {err}")),
+                Err(err) => return Err(JaqError::Execution(err.to_string())),
             }
         }
     }

--- a/src/json_viewer.rs
+++ b/src/json_viewer.rs
@@ -103,12 +103,17 @@ impl JsonViewer {
                 (guide, Some(self.state.create_graphemes(area.0, area.1)))
             }
             Err(e) => {
+                // Keep showing the input; the result pane stays put.
                 self.state.stream = JsonStream::new(self.json.iter());
 
-                (
-                    Some(GuideMessage::JqFailed(e.to_string())),
-                    Some(self.state.create_graphemes(area.0, area.1)),
-                )
+                // An incomplete/invalid filter is the normal state while typing,
+                // so stay quiet about it; only surface genuine runtime errors.
+                let guide = match e {
+                    json::JaqError::Invalid(_) => None,
+                    json::JaqError::Execution(msg) => Some(GuideMessage::JqFailed(msg)),
+                };
+
+                (guide, Some(self.state.create_graphemes(area.0, area.1)))
             }
         }
     }


### PR DESCRIPTION
## Problem

jaq runs on each (debounced) keystroke, so a half-typed filter — e.g. ending in `|` — fails to parse. The result was a raw `Debug` dump of jaq's internal parser structs flashing in the guide line on nearly every keypress:

```
jq failed: `jq filter parsing failed: [(File { code: ". | .user | ", path: () }, Parse([(Term, "")]))]`
```

Two issues: the message is an internal `Debug` representation, and erroring at all on an *incomplete* expression (the normal state while typing) is noise.

## Fix

`run_jaq` now returns a typed `JaqError`:

- **`Invalid`** — parse/compile failure (an incomplete or malformed expression, expected while typing).
- **`Execution`** — the filter parsed and compiled but failed at runtime (a real problem worth reporting).

The viewer **suppresses** the guide message for `Invalid` and leaves the view in place, so typing a multi-stage filter is quiet. **`Execution`** errors are still reported, now with jaq's `Display` message instead of the `Debug` dump.

## Notes

This is a lightweight take on #63 (don't choke on an incomplete expression): it stops the nagging without yet evaluating the longest valid prefix, which would be a larger change. Partially addresses #63.