### PR TITLE
fix(guide): keep the guide line from collapsing the layout

### DIFF
--- a/src/guide.rs
+++ b/src/guide.rs
@@ -80,6 +80,31 @@ pub fn copy_to_clipboard_message(content: &str) -> GuideMessage {
     }
 }
 
+/// A guide state that occupies exactly one (blank) row.
+///
+/// Used to reserve the guide line when there is no message to show, so the
+/// pane never collapses to zero rows and the panes below it stay put.
+fn blank_line() -> status::State {
+    status::State::new(" ", Severity::Success)
+}
+
+/// Graphemes for the guide pane's initial state.
+///
+/// With hints enabled this reserves one blank row so the guide line is present
+/// from the first frame — otherwise the first message would shift the panes
+/// below it. With `--no-hint` the guide is permanently empty.
+pub fn initial_graphemes(
+    no_hint: bool,
+    width: u16,
+    height: u16,
+) -> promkit_widgets::core::grapheme::StyledGraphemes {
+    if no_hint {
+        Default::default()
+    } else {
+        blank_line().create_graphemes(width, height)
+    }
+}
+
 /// Spawn a task that listens for guide actions and updates the guide view accordingly.
 pub fn start_guide_task(
     mut action_rx: mpsc::Receiver<GuideAction>,
@@ -96,7 +121,13 @@ pub fn start_guide_task(
                         Default::default()
                     } else {
                         match action {
-                            GuideAction::Clear => status::State::default().create_graphemes(area.0, area.1),
+                            // Render a single blank line rather than an empty
+                            // state. An empty state produces zero rows, which the
+                            // renderer drops entirely (terminal.rs filters out
+                            // empty panes), collapsing the guide line and shifting
+                            // the JSON viewer up — and back down when a message
+                            // reappears. Reserving one row keeps the layout stable.
+                            GuideAction::Clear => blank_line().create_graphemes(area.0, area.1),
                             GuideAction::Show(message) => message_to_state(message).create_graphemes(area.0, area.1),
                         }
                     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,7 +242,10 @@ async fn main() -> anyhow::Result<()> {
                     Index::QueryEditor,
                     query_editor.create_graphemes(terminal_size.0, terminal_size.1),
                 ),
-                (Index::Guide, StyledGraphemes::default()),
+                (
+                    Index::Guide,
+                    guide::initial_graphemes(config.no_hint, terminal_size.0, terminal_size.1),
+                ),
                 (Index::Completion, StyledGraphemes::default()),
                 (Index::JsonViewer, StyledGraphemes::default()),
             ]


### PR DESCRIPTION
## Problem

The TUI stacks four panes vertically: query editor, guide, completion, and JSON viewer. The guide line shows transient status messages (`result: …`, `jq failed: …`, copy notifications, etc.).

When there was **no** message to show, the guide was rendered from an empty `status::State`, which produces zero rows. The renderer drops zero-row panes entirely (`Terminal::draw` filters out panes whose `wrapped_lines` is empty), so the guide line disappeared and the JSON viewer slid up by one row. As soon as a status message appeared, the pane reclaimed its row and pushed everything back down.

The result: on every keystroke that toggled a status message on or off, the entire JSON view jumped up and down — distracting during normal editing.

## Fix

Reserve the guide line as a single blank row whenever there is no message, so the pane never collapses to zero rows and the panes below it stay put:

- `GuideAction::Clear` now renders one blank line instead of an empty state.
- The initial render reserves the same blank row, so the layout is stable from the first frame (previously the first status message would shift everything down).

`--no-hint` is unchanged: the guide stays permanently empty (consistently zero rows), so there is no jump in that mode either.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy`
- `cargo test`
- `cargo build --bins`

All pass. The behavior is a TUI layout change best confirmed interactively: type a filter that toggles between valid and invalid (e.g. `.` → `.foo` → `.` ) and observe the JSON view no longer jumps as the status line appears/disappears.