### PR TITLE
fix: report a broken config file instead of silently using defaults

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -185,9 +185,9 @@ async fn main() -> anyhow::Result<()> {
                 .map_err(|e| anyhow!("Failed to read configuration file: {e}"))
         })
         .and_then(|content| Config::load_from(&content))
-        .unwrap_or_else(|_e| {
-            Config::load_from(DEFAULT_CONFIG).expect("Failed to load default configuration")
-        });
+        // a missing file is already seeded with the defaults by ensure_file_exists,
+        // so anything failing here is a real problem the user should hear about
+        .map_err(|e| anyhow!("{e}"))?;
 
     // Set up terminal
     crossterm::terminal::enable_raw_mode()?;


### PR DESCRIPTION
Closes #117.

## What's broken

A config file that fails to parse is discarded silently. No message, no warning, exit 0, and every customization is gone with no indication why.

A config that is valid TOML but incomplete does it too, which is the easier way to hit this by accident:

```
$ cat /tmp/partial.toml
no_hint = true

$ jnv --config /tmp/partial.toml
(defaults, no mention that the file was ignored)
```

The error was there all along, just thrown away:

```
TOML parse error at line 1, column 1
  |
1 | no_hint = true
  | ^
missing field `reactivity_control`
```

## The cause

`unwrap_or_else(|_e| ...)` in `main` swallows the error and substitutes `DEFAULT_CONFIG`.

## The fix

Propagate it. Now:

```
$ jnv --config /tmp/partial.toml
Error: TOML parse error at line 1, column 1
  |
1 | no_hint = true
  | ^
missing field `reactivity_control`

$ echo $?
1
```

## Why failing is right here, rather than warning and continuing

`ensure_file_exists` already creates the file with the defaults when it is absent, for both the explicit `--config` path and the default location. So "no config" is handled before this point and never reaches it.

That means anything failing here is a file that exists and is broken, which is worth stopping for. A user who passes `--config` and gets defaults instead has silently lost their settings.

Tell me if you would rather warn and continue and I will change it.

## Verification

A valid config still loads: running with `default.toml` gets past config loading to terminal setup as before.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` and `cargo build` all pass, matching the five steps in `ci.yml`.

No test added, because the repo currently has no test target at all and `cargo test` reports 0 tests. Adding a harness felt like a bigger change than the fix. Happy to add one if you want the infrastructure.
